### PR TITLE
fix(deps): bump Microsoft.SemanticKernel.Core to 1.71.0 (CVE-2026-25592)

### DIFF
--- a/samples/dotnet/a2a/tba-client/src/TBAAPI.V3Client/TBAAPI.V3Client.csproj
+++ b/samples/dotnet/a2a/tba-client/src/TBAAPI.V3Client/TBAAPI.V3Client.csproj
@@ -22,7 +22,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.7.1" />
+		<PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.71.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.9.28">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/samples/dotnet/grpc/tba-client/src/TBAAPI.V3Client/TBAAPI.V3Client.csproj
+++ b/samples/dotnet/grpc/tba-client/src/TBAAPI.V3Client/TBAAPI.V3Client.csproj
@@ -22,7 +22,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.7.1" />
+		<PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.71.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.9.28">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/samples/dotnet/mcp/tba-client/src/TBAAPI.V3Client/TBAAPI.V3Client.csproj
+++ b/samples/dotnet/mcp/tba-client/src/TBAAPI.V3Client/TBAAPI.V3Client.csproj
@@ -22,7 +22,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.7.1" />
+		<PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.71.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.9.28">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/samples/dotnet/signalr/tba-client/src/TBAAPI.V3Client/TBAAPI.V3Client.csproj
+++ b/samples/dotnet/signalr/tba-client/src/TBAAPI.V3Client/TBAAPI.V3Client.csproj
@@ -22,7 +22,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.7.1" />
+		<PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.71.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.9.28">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/samples/dotnet/websockets/tba-client/src/TBAAPI.V3Client/TBAAPI.V3Client.csproj
+++ b/samples/dotnet/websockets/tba-client/src/TBAAPI.V3Client/TBAAPI.V3Client.csproj
@@ -22,7 +22,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.7.1" />
+		<PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.71.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.9.28">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Resolves Dependabot alert [#10](https://github.com/bc3tech/yaap/security/dependabot/10).

## Summary

`Microsoft.SemanticKernel.Core` versions `< 1.71.0` contain a **critical** Arbitrary File Write vulnerability via AI Agent Function Calling in the .NET SDK ([CVE-2026-25592](https://nvd.nist.gov/vuln/detail/CVE-2026-25592)).

The package was pinned at the vulnerable `1.7.1` directly in five sample `tba-client` csproj files. This PR bumps each of them to the patched `1.71.0`.

## Changes

| File | Before | After |
|---|---|---|
| `samples/dotnet/a2a/tba-client/src/TBAAPI.V3Client/TBAAPI.V3Client.csproj` | `1.7.1` | `1.71.0` |
| `samples/dotnet/grpc/tba-client/src/TBAAPI.V3Client/TBAAPI.V3Client.csproj` | `1.7.1` | `1.71.0` |
| `samples/dotnet/mcp/tba-client/src/TBAAPI.V3Client/TBAAPI.V3Client.csproj` | `1.7.1` | `1.71.0` |
| `samples/dotnet/signalr/tba-client/src/TBAAPI.V3Client/TBAAPI.V3Client.csproj` | `1.7.1` | `1.71.0` |
| `samples/dotnet/websockets/tba-client/src/TBAAPI.V3Client/TBAAPI.V3Client.csproj` | `1.7.1` | `1.71.0` |

The Dependabot alert is filed against the `a2a` sample, but the same vulnerable version is duplicated across the other four sample variants — fixed all five for consistency.

## Notes

- A pre-existing `NU1008` build error (CPM enabled but `Version=` set inline on `PackageReference`) was already present on `main` and is **not** addressed here, as it is unrelated to the security alert.
- 1.71.0 is the minimum patched version as identified by the Dependabot advisory.