### PR TITLE
ci(security): add least-privilege permissions to build-and-release workflow

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -12,6 +12,9 @@ on:
 env:
   VERSION: ${{ vars.BASE_VERSION }}.${{ github.run_number }}
 
+permissions:
+  contents: read
+
 jobs:
   build-and-pack:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Resolves CodeQL code-scanning alert [#3](https://github.com/bc3tech/yaap/security/code-scanning/3) (and the sibling alert [#1](https://github.com/bc3tech/yaap/security/code-scanning/1), same root cause on the same workflow).

## Issue

Rule: `actions/missing-workflow-permissions` (medium severity, CodeQL)
> Workflows should contain explicit permissions to restrict the scope of the default GITHUB_TOKEN.

The `build-and-release.yaml` workflow had no top-level `permissions:` block, so the `build-and-pack` and `publish-to-nuget` jobs ran with the repository default token scope (potentially `contents: write` and more) without needing it.

## Fix

Added a workflow-level least-privilege block:

```yaml
permissions:
  contents: read
```

This locks down all jobs to read-only by default. The `tag-release` job already declares its own `permissions: contents: write` override, which is required for `git push --tags` and `gh release create` — so its behavior is unchanged.

NuGet publish uses `secrets.NUGET_API_KEY`, not `GITHUB_TOKEN`, so `publish-to-nuget` does not need any elevated permissions.

## Verification

- `build-and-pack`: checkout / build / test / upload-artifact — all work with `contents: read`.
- `publish-to-nuget`: download-artifact / `dotnet nuget push` with external API key — `contents: read` is sufficient.
- `tag-release`: keeps its existing `contents: write` job-level override.